### PR TITLE
Improved paging in the example project

### DIFF
--- a/example/src/main/java/nl/nos/imagin/example/gallery/GalleryActivity.kt
+++ b/example/src/main/java/nl/nos/imagin/example/gallery/GalleryActivity.kt
@@ -3,8 +3,11 @@ package nl.nos.imagin.example.gallery
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.support.v4.app.SharedElementCallback
 import android.support.v7.app.AppCompatActivity
+import android.view.View
 import android.view.animation.DecelerateInterpolator
+import android.widget.ImageView
 import kotlinx.android.synthetic.main.activity_gallery.*
 import nl.nos.imagin.example.R
 import nl.nos.imagin.example.data.Repository
@@ -33,6 +36,26 @@ class GalleryActivity : AppCompatActivity(), GalleryPagerAdapter.OnSwipedToClose
         view_pager.post {
             supportStartPostponedEnterTransition()
         }
+
+        // Map the shared element transition for when the page has changed.
+        setEnterSharedElementCallback(object : SharedElementCallback() {
+            override fun onMapSharedElements(
+                names: MutableList<String>,
+                sharedElements: MutableMap<String, View>
+            ) {
+                if (names.isEmpty()) return
+
+                val selectedPictureName = repository.getPictures()[view_pager.currentItem].name
+
+                val imageView = view_pager.findViewWithTag<ImageView>(
+                    selectedPictureName
+                ) ?: return
+
+                names[0] = imageView.transitionName
+                sharedElements.clear()
+                sharedElements[imageView.transitionName] = imageView
+            }
+        })
     }
 
     override fun onSwipeToClose() {

--- a/example/src/main/java/nl/nos/imagin/example/gallery/GalleryPagerAdapter.kt
+++ b/example/src/main/java/nl/nos/imagin/example/gallery/GalleryPagerAdapter.kt
@@ -54,6 +54,7 @@ class GalleryPagerAdapter : PagerAdapter() {
             }
 
         imageView.transitionName = picture.name
+        imageView.tag = picture.name
 
         container.addView(imageWrapper)
 

--- a/example/src/main/java/nl/nos/imagin/example/overview/OverviewActivity.kt
+++ b/example/src/main/java/nl/nos/imagin/example/overview/OverviewActivity.kt
@@ -2,6 +2,7 @@ package nl.nos.imagin.example.overview
 
 import android.os.Bundle
 import android.support.v4.app.ActivityOptionsCompat
+import android.support.v4.app.SharedElementCallback
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.GridLayoutManager
 import android.view.View
@@ -25,6 +26,19 @@ class OverviewActivity : AppCompatActivity(), OverviewAdapter.OnPictureClickedLi
 
         recycler_view.layoutManager = GridLayoutManager(this, 2)
         recycler_view.adapter = adapter
+
+        // Map the shared element transition for when the page has changed.
+        setExitSharedElementCallback(object : SharedElementCallback() {
+            override fun onMapSharedElements(
+                names: MutableList<String>,
+                sharedElements: MutableMap<String, View>
+            ) {
+                if (names.isEmpty()) return
+
+                val selectedView = recycler_view.findViewWithTag<View>(names[0]) ?: return
+                sharedElements[names[0]] = selectedView
+            }
+        })
     }
 
     override fun onPictureClicked(view: View, picture: Picture, position: Int) {

--- a/example/src/main/java/nl/nos/imagin/example/overview/OverviewAdapter.kt
+++ b/example/src/main/java/nl/nos/imagin/example/overview/OverviewAdapter.kt
@@ -28,6 +28,7 @@ class OverviewAdapter : RecyclerView.Adapter<PictureViewHolder>() {
         )
 
         viewHolder.itemView.transitionName = picture.name
+        viewHolder.itemView.tag = picture.name
 
         viewHolder.itemView.setOnClickListener {
             onPictureClickedListener?.onPictureClicked(viewHolder.itemView, picture, position)


### PR DESCRIPTION
The shared element transition now works properly after changing the page in the ViewPager and when going back to the overview.